### PR TITLE
Fix: Inactive Selection to ligth theme

### DIFF
--- a/themes/trybe-theme-light.json
+++ b/themes/trybe-theme-light.json
@@ -346,7 +346,7 @@
     "list.focusForeground": "#036B52",
     "list.highlightForeground": "#036B52",
     "list.hoverBackground": "#FFFFFF1a",
-    "list.inactiveSelectionBackground": "#FFFFFF33",
+    "list.inactiveSelectionBackground": "#326857",
     "activityBar.background": "#036B52",
     "activityBar.dropBackground": "#036B5280",
     "activityBarBadge.background": "#036B52",

--- a/themes/trybe-theme-light.json
+++ b/themes/trybe-theme-light.json
@@ -347,6 +347,7 @@
     "list.highlightForeground": "#036B52",
     "list.hoverBackground": "#FFFFFF1a",
     "list.inactiveSelectionBackground": "#326857",
+    "list.inactiveSelectionForeground": "#ffffff",
     "activityBar.background": "#036B52",
     "activityBar.dropBackground": "#036B5280",
     "activityBarBadge.background": "#036B52",

--- a/themes/trybe-theme-light.json
+++ b/themes/trybe-theme-light.json
@@ -340,7 +340,7 @@
     "input.background": "#ffffff",
     "inputOption.activeBorder": "#036B52",
     "list.activeSelectionBackground": "#2fc18c",
-    "list.activeSelectionForeground": "#023031",
+    "list.activeSelectionForeground": "#ffffff",
     "list.dropBackground": "#036B5280",
     "list.focusBackground": "#036B5280",
     "list.focusForeground": "#036B52",


### PR DESCRIPTION
Quando estamos editando um arquivo, ele deveria mostrar na visualização que ele esta selecionado
desta forma :
![image](https://user-images.githubusercontent.com/21278380/234417073-2c609d7d-06f6-4ce5-a5cd-363e530a54f2.png)

No tema atual, eu não consigo visualizar direito o arquivo selecionado

![image](https://user-images.githubusercontent.com/21278380/234417382-c0c98871-6be5-41fe-b80a-98f8d80916fc.png)
